### PR TITLE
🐛 Replace DataOutputStream with BufferedOutputStream to fix UTF-8 encoding bug

### DIFF
--- a/src/main/java/ntfyJava/core/publish/PubServiceImpl.java
+++ b/src/main/java/ntfyJava/core/publish/PubServiceImpl.java
@@ -8,10 +8,11 @@ import ntfyJava.core.model.PRIORITY;
 import ntfyJava.core.model.RequestModel;
 import ntfyJava.core.common.NtfyConstants;
 
-import java.io.DataOutputStream;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 
 public class PubServiceImpl implements PubService {
@@ -55,7 +56,7 @@ public class PubServiceImpl implements PubService {
             URL obj = new URL(request.getUrl());
             HttpURLConnection con = (HttpURLConnection) obj.openConnection();
             con.setRequestMethod(NtfyConstants.POST);
-            con.setRequestProperty(NtfyConstants.CONTENT_TYPE, "application/json");
+            con.setRequestProperty(NtfyConstants.CONTENT_TYPE, "application/json; charset=utf-8");
 
             //handle authentication (if supplied)
             if (request.getAccessToken() != null) {
@@ -66,9 +67,9 @@ public class PubServiceImpl implements PubService {
             // Enable input/output streams
             con.setDoOutput(true);
 
-            try (DataOutputStream wr = new DataOutputStream(con.getOutputStream())) {
-                wr.writeBytes(new ObjectMapper().writeValueAsString(createPublishRequest(request)));
-                wr.flush();
+            try (BufferedOutputStream outputStream = new BufferedOutputStream(con.getOutputStream());) {
+                String json = new ObjectMapper().writeValueAsString(createPublishRequest(request));
+                outputStream.write(json.getBytes(StandardCharsets.UTF_8));
             }
             // Get the response from the server
             int responseCode = con.getResponseCode();

--- a/src/main/java/ntfyJava/example/PublishExample.java
+++ b/src/main/java/ntfyJava/example/PublishExample.java
@@ -15,7 +15,7 @@ public class PublishExample {
         PubClient client = new NtfyClient(ClientType.PUB).getClient();
         NtfyRequest request = new NtfyRequest();
         request.setTopic("test_ntfy2");
-        request.setMessage("Look ma, **bold text**, *italics*, ...");
+        request.setMessage("Look ma, **bold text**, *italics*, emoji 🥳 🤟 🕊️...");
         request.setTitle("This is the obj msg");
         request.setPriority(PRIORITY.MAX);
         request.setAttach("https://media.licdn.com/dms/image/D4E03AQEZTNXuX3kG7g/profile-displayphoto-shrink_400_400/0/1669618932666?e=1699488000&v=beta&t=q2z_UDFvwTZa02SligKZqgwk66BjuXQZxWtQF_K1Jqw");


### PR DESCRIPTION
For reasons unknown to me, the DataOutputStream class used previously malforms emoji. This is fixed by using a BufferedOutputStream instead. Fixes https://github.com/MaheshBabu11/ntfy-java/issues/13.

See also: https://stackoverflow.com/questions/7630242/why-does-dataoutputstream-writeutf-add-additional-2-bytes-at-the-beginning